### PR TITLE
Add summarize by topic test

### DIFF
--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -13,3 +13,29 @@ def test_summarize_basic_text_contains_keywords(monkeypatch):
     articles = [{"title": "Economy", "desc": "The economy is booming"}]
     result = summarizer.summarize_articles(articles)
     assert "economy" in result.lower()
+
+
+def test_summarize_by_topic_produces_summaries(monkeypatch):
+    """Each topic should map to a summary or a default message."""
+
+    def fake_sum(text, **kwargs):
+        if "sports" in text.lower():
+            return [{"summary_text": ""}]
+        return [{"summary_text": text[:50]}]
+
+    monkeypatch.setattr(summarizer, "summarizer", fake_sum)
+
+    topics = ["economy", "sports"]
+    articles = [
+        {"title": "Economy on the rise", "desc": "GDP grows 3% this quarter"},
+        {
+            "title": "Local sports team wins",
+            "desc": "Sports fans celebrate victory",
+        },
+    ]
+
+    summaries = summarizer.summarize_by_topic(topics, articles)
+    assert set(summaries) == set(topics)
+    for topic in topics:
+        summary = summaries[topic]
+        assert summary == "No news available." or summary


### PR DESCRIPTION
## Summary
- test summarizing articles by topic returns non-empty summaries or default message

## Testing
- `pytest -q` *(fails: IndentationError in tests/test_cli.py, SyntaxError in src/dailynews/fetcher.py)*
- `pytest tests/test_summarizer.py::test_summarize_by_topic_produces_summaries -q`


------
https://chatgpt.com/codex/tasks/task_e_68c44a4a84088322b2b6e0f7f11635eb