### PR TITLE
Add API backend and mobile apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ build/
 *.egg-info/
 .DS_Store
 .env
+mobile/flutter_app/.dart_tool/
+mobile/flutter_app/build/
+mobile/react_native_app/node_modules/
+mobile/react_native_app/.expo/

--- a/README.md
+++ b/README.md
@@ -1,8 +1,22 @@
 # DailyNews
 
 DailyNews fetches recent headlines from the [GDELT](https://www.gdeltproject.org/) API,
-summarises them using a small transformer model and optionally emails the
-summary to you.
+summarises them with a Hugging Face model, exposes a FastAPI backend for mobile
+clients, and optionally emails the summary to you.
+
+## Features
+
+- Click-based CLI with optional backend integration (`--use-api`).
+- FastAPI service exposing `/health` and `/summary` endpoints with CORS enabled
+  for local development tooling and mobile simulators.
+- Configurable Hugging Face model via `HF_MODEL` and `HF_API_TOKEN` environment
+  variables with an offline testing stub (`DAILYNEWS_SKIP_HF=1`).
+- Mobile clients:
+  - Flutter application with topic chips, configurable filters, and tappable
+    headlines.
+  - React Native (Expo) application with multi-select topics and rich status
+    handling.
+- Email delivery using SMTP environment variables.
 
 ## Quick start
 
@@ -10,61 +24,136 @@ summary to you.
 python3 -m venv .venv && source .venv/bin/activate
 pip install -U pip
 pip install -e .
+```
 
-# See available options
+Create a `.env` file (or export the variables in your shell) using
+[`examples/.env.example`](examples/.env.example) as a template. At minimum set:
+
+```bash
+export HF_API_TOKEN="<your HF token>"
+export HF_MODEL="facebook/MobileLLM-R1-950M"
+export API_PORT=8000
+# Optional: change if your backend runs elsewhere
+export DAILYNEWS_API_URL="http://localhost:8000"
+```
+
+Never commit tokens to the repository—see [SECURITY.md](SECURITY.md).
+
+### Run the backend API
+
+```bash
+# Requires the virtual environment above
+uvicorn server.main:app --reload --port "${API_PORT:-8000}"
+# or use the helper script
+./scripts/run_server.sh
+```
+
+The API will be reachable at `http://localhost:${API_PORT}/summary`.
+
+### Use the CLI
+
+```bash
+# See available options (note the new --use-api flag)
 dailynews --help
 
-# Fetch finance, economy and politics news for the last 8 hours
+# Fetch finance/economy/politics locally (no API)
 dailynews -t "finance,economy,politics" -h 8
 
-# Fetch US English finance news
-# Specify region and language
+# Use the backend API instead of local summarisation
+dailynews --use-api -t finance -h 4
+
+# Include region and language filters
 dailynews -t finance -r US -l en -h 24
 ```
 
-The first run may download the summarisation model which can take a minute.
-Set ``DAILYNEWS_SKIP_HF=1`` to skip loading the model (useful for tests).
-
-
-## Troubleshooting
-
-- `ConnectionError`: check your internet connection.
-- JSON shape changes: the GDELT API occasionally adds or removes fields.  The
-  tool will log a warning and return no results.
-- Token length warnings: summarisation input is truncated to ~1000 characters to
-  avoid overflow.
-
-## Scheduling on macOS
-
-```bash
-crontab -e
-# Example line (adjust paths)
-0 7 * * * /path/to/project/.venv/bin/dailynews -t "finance,economy,politics" -h 8 >> /path/to/project/dailynews.log 2>&1
-```
-
-An alternative is to use [`scripts/cron_example.sh`](scripts/cron_example.sh) to
-activate the virtual environment before running the command.
-
-## Optional email usage
-
-```bash
-cp examples/.env.example .env
-# edit .env and export the variables
-source .env
-dailynews -e you@example.com
-```
-
-## Development
-
-Run tests with:
+When running tests or developing offline, disable the Hugging Face model:
 
 ```bash
 export DAILYNEWS_SKIP_HF=1
 pytest -q
 ```
 
-Roadmap:
+### Email summaries
 
-- Future mobile app (Kivy or small Flask API)
-- Multi-language support
-- Docker packaging
+Copy the sample file, fill in the SMTP settings, then source it before running
+with `-e`:
+
+```bash
+cp examples/.env.example .env
+# edit .env to add EMAIL_* settings
+source .env
+dailynews -e you@example.com
+```
+
+## Mobile clients
+
+Both mobile apps expect the backend to be running. Adjust the base URL to point
+at your machine from the simulator/emulator.
+
+### Flutter (`mobile/flutter_app`)
+
+1. Install Flutter 3.0+.
+2. From `mobile/flutter_app`, run `flutter pub get`.
+3. Launch the backend API and ensure it is accessible.
+4. Start the app:
+
+   ```bash
+   flutter run --dart-define=DAILYNEWS_API_BASE="http://localhost:8000"
+   ```
+
+   - Android emulator: use `http://10.0.2.2:8000`.
+   - iOS simulator: `http://127.0.0.1:8000`.
+   - Physical device: replace with your machine's LAN IP.
+
+See [`mobile/flutter_app/README.md`](mobile/flutter_app/README.md) for more
+platform-specific notes.
+
+### React Native / Expo (`mobile/react_native_app`)
+
+1. Install Node.js 18+ and Expo CLI (`npm install -g expo-cli`).
+2. From `mobile/react_native_app`, run `npm install`.
+3. Copy `.env.example` to `.env` or export `EXPO_PUBLIC_BASE_URL`.
+4. Start Expo:
+
+   ```bash
+   npm run start
+   # then press a/i/w for Android/iOS/web respectively
+   ```
+
+   - Android emulator default: `http://10.0.2.2:8000`.
+   - iOS simulator: `http://127.0.0.1:8000`.
+   - Physical devices must share the same network as your machine.
+
+Refer to [`mobile/react_native_app/README.md`](mobile/react_native_app/README.md)
+for troubleshooting tips and network configuration guidance.
+
+## Testing
+
+```bash
+export DAILYNEWS_SKIP_HF=1
+pytest -q
+```
+
+All external network calls are monkeypatched in tests, ensuring deterministic
+and offline-friendly behaviour.
+
+## Troubleshooting
+
+- `Backend API returned invalid JSON` – ensure the FastAPI server is running
+  and reachable.
+- `HF_MODEL and HF_API_TOKEN must be set` – the CLI/backend attempted to load a
+  model without credentials.
+- Mobile devices cannot reach the backend – confirm the correct base URL for
+  your simulator/emulator and that the host firewall allows local connections.
+- Summaries look stale – reduce the `--hours` window or adjust topics.
+
+## Scheduling
+
+Use `scripts/cron_example.sh` as a template for cron jobs that activate your
+virtual environment before calling the CLI.
+
+## Security
+
+Environment variables contain all sensitive material (Hugging Face tokens,
+SMTP credentials). Rotate tokens immediately if exposed and review
+[SECURITY.md](SECURITY.md) for recommended practices.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Guidelines
+
+- **Never commit secrets**. Hugging Face tokens, SMTP credentials, and mobile
+  configuration secrets must be supplied via environment variables or `.env`
+  files that stay out of version control.
+- Rotate Hugging Face tokens immediately if they are exposed and invalidate any
+  leaked SMTP credentials.
+- Limit sharing of `.env` files and prefer using password managers or secret
+  stores for distribution.
+- When testing, use `DAILYNEWS_SKIP_HF=1` to avoid unexpected calls to external
+  services.
+- Review and prune dependencies regularly. Apply security updates for Python,
+  Flutter, and Node.js environments as they become available.

--- a/examples/.env.example
+++ b/examples/.env.example
@@ -1,7 +1,19 @@
-# Copy this file to .env and fill in your SMTP settings
+# Hugging Face settings (required for live summarisation)
+HF_API_TOKEN=
+HF_MODEL=facebook/MobileLLM-R1-950M
+
+# FastAPI backend configuration
+API_PORT=8000
+DAILYNEWS_API_URL=http://localhost:8000
+
+# Email configuration (optional)
 EMAIL_HOST=smtp.example.com
 EMAIL_PORT=465
 EMAIL_USERNAME=your_username
 EMAIL_PASSWORD=your_password
 EMAIL_FROM=your_from@example.com
 EMAIL_USE_SSL=true
+
+# Mobile client defaults
+FLUTTER_BASE_URL=http://localhost:8000
+EXPO_PUBLIC_BASE_URL=http://localhost:8000

--- a/mobile/flutter_app/README.md
+++ b/mobile/flutter_app/README.md
@@ -1,0 +1,35 @@
+# DailyNews Flutter App
+
+A lightweight Flutter client that talks to the DailyNews FastAPI backend.
+
+## Prerequisites
+
+- Flutter SDK 3.0+
+- Backend running locally (see repository README)
+
+## Getting started
+
+```bash
+flutter pub get
+flutter run --dart-define=DAILYNEWS_API_BASE="http://localhost:8000"
+```
+
+If you are running on an emulator/device update the base URL:
+
+- Android emulator: `--dart-define=DAILYNEWS_API_BASE="http://10.0.2.2:8000"`
+- iOS simulator: `--dart-define=DAILYNEWS_API_BASE="http://127.0.0.1:8000"`
+- Physical device: use your machine's LAN IP (ensure both devices share a
+  network).
+
+## Features
+
+- Topic chips for finance, economy, and politics plus a custom topic input
+- Hours dropdown (4/8/12/24) and optional region/language filters
+- Loading, error, and empty states
+- Scrollable summary with tappable headlines
+
+## Troubleshooting
+
+- `Backend returned XXX` – verify the API server is reachable from the device.
+- Nothing happens on tap – confirm the device/emulator has a default browser and
+  permissions to open external URLs.

--- a/mobile/flutter_app/lib/api_client.dart
+++ b/mobile/flutter_app/lib/api_client.dart
@@ -1,0 +1,92 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import 'config.dart';
+
+class Headline {
+  Headline({
+    required this.title,
+    required this.url,
+    required this.sourceDomain,
+    required this.seenDate,
+  });
+
+  final String title;
+  final String url;
+  final String sourceDomain;
+  final String seenDate;
+
+  factory Headline.fromJson(Map<String, dynamic> json) {
+    return Headline(
+      title: json['title']?.toString() ?? '',
+      url: json['url']?.toString() ?? '',
+      sourceDomain: json['source_domain']?.toString() ?? '',
+      seenDate: json['seendate']?.toString() ?? '',
+    );
+  }
+}
+
+class SummaryResponse {
+  SummaryResponse({
+    required this.topics,
+    required this.hours,
+    required this.summary,
+    required this.headlines,
+    required this.region,
+    required this.language,
+  });
+
+  final List<String> topics;
+  final int hours;
+  final String summary;
+  final List<Headline> headlines;
+  final String? region;
+  final String? language;
+
+  factory SummaryResponse.fromJson(Map<String, dynamic> json) {
+    final dynamic topicsValue = json['topics'];
+    final List<String> topics = topicsValue is List
+        ? topicsValue.map((e) => e.toString()).toList()
+        : topicsValue.toString().split(',').map((e) => e.trim()).where((e) => e.isNotEmpty).toList();
+    final List<dynamic> rawHeadlines = (json['headlines'] as List<dynamic>? ?? <dynamic>[]);
+    return SummaryResponse(
+      topics: topics,
+      hours: int.tryParse(json['hours']?.toString() ?? '0') ?? 0,
+      summary: json['summary']?.toString() ?? 'No news available.',
+      region: json['region']?.toString(),
+      language: json['language']?.toString(),
+      headlines: rawHeadlines
+          .map((dynamic item) => Headline.fromJson(item as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+}
+
+class DailyNewsApiClient {
+  DailyNewsApiClient({http.Client? client}) : _client = client ?? http.Client();
+
+  final http.Client _client;
+
+  Future<SummaryResponse> fetchSummary({
+    required List<String> topics,
+    required int hours,
+    String? region,
+    String? language,
+  }) async {
+    final Uri uri = Uri.parse('$baseUrl/summary').replace(queryParameters: <String, String?>{
+      'topics': topics.join(','),
+      'hours': hours.toString(),
+      'region': region,
+      'language': language,
+    });
+
+    final http.Response response = await _client.get(uri).timeout(const Duration(seconds: 15));
+    if (response.statusCode != 200) {
+      throw Exception('Backend returned ${response.statusCode}');
+    }
+
+    final Map<String, dynamic> data = json.decode(response.body) as Map<String, dynamic>;
+    return SummaryResponse.fromJson(data);
+  }
+}

--- a/mobile/flutter_app/lib/config.dart
+++ b/mobile/flutter_app/lib/config.dart
@@ -1,0 +1,4 @@
+const String baseUrl = String.fromEnvironment(
+  'DAILYNEWS_API_BASE',
+  defaultValue: 'http://localhost:8000',
+);

--- a/mobile/flutter_app/lib/main.dart
+++ b/mobile/flutter_app/lib/main.dart
@@ -1,0 +1,261 @@
+import 'package:flutter/material.dart';
+
+import 'api_client.dart';
+import 'widgets/headline_tile.dart';
+
+void main() {
+  runApp(const DailyNewsApp());
+}
+
+class DailyNewsApp extends StatelessWidget {
+  const DailyNewsApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'DailyNews',
+      theme: ThemeData(colorSchemeSeed: Colors.indigo, useMaterial3: true),
+      home: const DailyNewsHomePage(),
+    );
+  }
+}
+
+class DailyNewsHomePage extends StatefulWidget {
+  const DailyNewsHomePage({super.key});
+
+  @override
+  State<DailyNewsHomePage> createState() => _DailyNewsHomePageState();
+}
+
+class _DailyNewsHomePageState extends State<DailyNewsHomePage> {
+  final DailyNewsApiClient _client = DailyNewsApiClient();
+  final List<String> _defaultTopics = const ['finance', 'economy', 'politics'];
+  final Set<String> _selectedTopics = <String>{'finance', 'economy', 'politics'};
+  final TextEditingController _customTopicController = TextEditingController();
+  final TextEditingController _regionController = TextEditingController();
+  final TextEditingController _languageController = TextEditingController();
+
+  final List<int> _hourOptions = const [4, 8, 12, 24];
+
+  int _hours = 8;
+  bool _loading = false;
+  String? _error;
+  SummaryResponse? _summary;
+
+  @override
+  void dispose() {
+    _customTopicController.dispose();
+    _regionController.dispose();
+    _languageController.dispose();
+    super.dispose();
+  }
+
+  void _toggleTopic(String topic) {
+    setState(() {
+      if (_selectedTopics.contains(topic)) {
+        _selectedTopics.remove(topic);
+      } else {
+        _selectedTopics.add(topic);
+      }
+    });
+  }
+
+  void _addCustomTopic() {
+    final String topic = _customTopicController.text.trim();
+    if (topic.isEmpty) {
+      return;
+    }
+    setState(() {
+      _selectedTopics.add(topic);
+      _customTopicController.clear();
+    });
+  }
+
+  Future<void> _fetchSummary() async {
+    if (_selectedTopics.isEmpty) {
+      setState(() {
+        _error = 'Select at least one topic.';
+      });
+      return;
+    }
+
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+
+    try {
+      final SummaryResponse response = await _client.fetchSummary(
+        topics: _selectedTopics.toList(),
+        hours: _hours,
+        region: _regionController.text.trim().isEmpty ? null : _regionController.text.trim(),
+        language: _languageController.text.trim().isEmpty ? null : _languageController.text.trim(),
+      );
+      setState(() {
+        _summary = response;
+      });
+    } catch (error) {
+      setState(() {
+        _summary = null;
+        _error = error.toString();
+      });
+    } finally {
+      setState(() {
+        _loading = false;
+      });
+    }
+  }
+
+  Widget _buildTopicChips() {
+    final Iterable<Widget> chips = _defaultTopics.map((String topic) {
+      final bool selected = _selectedTopics.contains(topic);
+      return Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 4),
+        child: FilterChip(
+          label: Text(topic),
+          selected: selected,
+          onSelected: (_) => _toggleTopic(topic),
+        ),
+      );
+    });
+    return Wrap(children: chips.toList());
+  }
+
+  Widget _buildSummaryView() {
+    if (_loading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (_error != null) {
+      return Center(
+        child: Text(
+          _error!,
+          style: const TextStyle(color: Colors.red),
+        ),
+      );
+    }
+    if (_summary == null) {
+      return const Center(child: Text('Tap "Fetch Summary" to load the latest news.'));
+    }
+    if (_summary!.headlines.isEmpty) {
+      return Center(
+        child: Text(
+          _summary!.summary.isEmpty ? 'No news available.' : _summary!.summary,
+          textAlign: TextAlign.center,
+        ),
+      );
+    }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Text(
+          _summary!.summary,
+          style: Theme.of(context).textTheme.bodyLarge,
+        ),
+        const SizedBox(height: 16),
+        Text('Headlines', style: Theme.of(context).textTheme.titleMedium),
+        const SizedBox(height: 8),
+        ..._summary!.headlines.map((Headline headline) => HeadlineTile(headline: headline)),
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('DailyNews Mobile')),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Text('Topics', style: Theme.of(context).textTheme.titleMedium),
+              const SizedBox(height: 8),
+              _buildTopicChips(),
+              const SizedBox(height: 8),
+              Row(
+                children: <Widget>[
+                  Expanded(
+                    child: TextField(
+                      controller: _customTopicController,
+                      decoration: const InputDecoration(
+                        labelText: 'Add custom topic',
+                        border: OutlineInputBorder(),
+                      ),
+                      onSubmitted: (_) => _addCustomTopic(),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  ElevatedButton(
+                    onPressed: _addCustomTopic,
+                    child: const Text('Add'),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 16),
+              Row(
+                children: <Widget>[
+                  Expanded(
+                    child: InputDecorator(
+                      decoration: const InputDecoration(
+                        labelText: 'Hours',
+                        border: OutlineInputBorder(),
+                      ),
+                      child: DropdownButtonHideUnderline(
+                        child: DropdownButton<int>(
+                          value: _hours,
+                          isExpanded: true,
+                          items: _hourOptions
+                              .map(
+                                (int value) => DropdownMenuItem<int>(
+                                  value: value,
+                                  child: Text('$value hours'),
+                                ),
+                              )
+                              .toList(),
+                          onChanged: (int? value) {
+                            if (value != null) {
+                              setState(() => _hours = value);
+                            }
+                          },
+                        ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: TextField(
+                      controller: _regionController,
+                      decoration: const InputDecoration(
+                        labelText: 'Region (optional)',
+                        border: OutlineInputBorder(),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 8),
+              TextField(
+                controller: _languageController,
+                decoration: const InputDecoration(
+                  labelText: 'Language (optional)',
+                  border: OutlineInputBorder(),
+                ),
+              ),
+              const SizedBox(height: 16),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: _loading ? null : _fetchSummary,
+                  child: const Text('Fetch Summary'),
+                ),
+              ),
+              const SizedBox(height: 24),
+              _buildSummaryView(),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/flutter_app/lib/widgets/headline_tile.dart
+++ b/mobile/flutter_app/lib/widgets/headline_tile.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../api_client.dart';
+
+class HeadlineTile extends StatelessWidget {
+  const HeadlineTile({super.key, required this.headline});
+
+  final Headline headline;
+
+  Future<void> _openUrl(BuildContext context) async {
+    final Uri uri = Uri.tryParse(headline.url) ?? Uri();
+    if (uri.toString().isEmpty) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('No link available for this headline.')));
+      return;
+    }
+    if (!await launchUrl(uri, mode: LaunchMode.externalApplication)) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('Could not open the link.')));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 4),
+      child: ListTile(
+        title: Text(headline.title.isEmpty ? 'Untitled' : headline.title),
+        subtitle: Text(headline.sourceDomain.isEmpty
+            ? headline.seenDate
+            : '${headline.sourceDomain} • ${headline.seenDate}'),
+        onTap: () => _openUrl(context),
+        trailing: const Icon(Icons.open_in_new),
+      ),
+    );
+  }
+}

--- a/mobile/flutter_app/pubspec.yaml
+++ b/mobile/flutter_app/pubspec.yaml
@@ -1,0 +1,21 @@
+name: dailynews_flutter
+version: 1.0.0+1
+description: Flutter client for the DailyNews backend API.
+publish_to: "none"
+
+environment:
+  sdk: ">=3.0.0 <4.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  http: ^1.2.0
+  url_launcher: ^6.2.5
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^3.0.0
+
+flutter:
+  uses-material-design: true

--- a/mobile/react_native_app/.env.example
+++ b/mobile/react_native_app/.env.example
@@ -1,0 +1,1 @@
+EXPO_PUBLIC_BASE_URL=http://localhost:8000

--- a/mobile/react_native_app/App.js
+++ b/mobile/react_native_app/App.js
@@ -1,0 +1,313 @@
+import React, { useMemo, useState } from 'react';
+import { StatusBar } from 'expo-status-bar';
+import {
+  ActivityIndicator,
+  Linking,
+  Pressable,
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+
+import { fetchSummary } from './src/apiClient';
+
+const DEFAULT_TOPICS = ['finance', 'economy', 'politics'];
+const HOUR_OPTIONS = [4, 8, 12, 24];
+
+function TopicChip({ label, selected, onPress }) {
+  return (
+    <Pressable
+      style={[styles.chip, selected ? styles.chipSelected : null]}
+      onPress={onPress}
+    >
+      <Text style={selected ? styles.chipLabelSelected : styles.chipLabel}>{label}</Text>
+    </Pressable>
+  );
+}
+
+function HeadlineItem({ headline }) {
+  const handlePress = () => {
+    if (headline.url) {
+      Linking.openURL(headline.url).catch(() => {});
+    }
+  };
+
+  return (
+    <Pressable style={styles.headline} onPress={handlePress}>
+      <Text style={styles.headlineTitle}>{headline.title || 'Untitled'}</Text>
+      <Text style={styles.headlineMeta}>
+        {headline.source_domain ? `${headline.source_domain} • ${headline.seendate}` : headline.seendate}
+      </Text>
+    </Pressable>
+  );
+}
+
+export default function App() {
+  const [selectedTopics, setSelectedTopics] = useState(new Set(DEFAULT_TOPICS));
+  const [customTopic, setCustomTopic] = useState('');
+  const [hours, setHours] = useState(8);
+  const [region, setRegion] = useState('');
+  const [language, setLanguage] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [result, setResult] = useState(null);
+
+  const topicsArray = useMemo(() => Array.from(selectedTopics), [selectedTopics]);
+
+  const toggleTopic = (topic) => {
+    const next = new Set(selectedTopics);
+    if (next.has(topic)) {
+      next.delete(topic);
+    } else {
+      next.add(topic);
+    }
+    setSelectedTopics(next);
+  };
+
+  const addCustomTopic = () => {
+    const trimmed = customTopic.trim();
+    if (!trimmed) {
+      return;
+    }
+    const next = new Set(selectedTopics);
+    next.add(trimmed);
+    setSelectedTopics(next);
+    setCustomTopic('');
+  };
+
+  const fetchData = async () => {
+    if (topicsArray.length === 0) {
+      setError('Please select at least one topic.');
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const summary = await fetchSummary({
+        topics: topicsArray,
+        hours,
+        region: region.trim() || undefined,
+        language: language.trim() || undefined,
+      });
+      setResult(summary);
+    } catch (err) {
+      setResult(null);
+      setError(err.message || 'Failed to fetch summary.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <StatusBar style="auto" />
+      <ScrollView contentContainerStyle={styles.scrollContent}>
+        <Text style={styles.title}>DailyNews Mobile</Text>
+
+        <Text style={styles.sectionTitle}>Topics</Text>
+        <View style={styles.chipContainer}>
+          {DEFAULT_TOPICS.map((topic) => (
+            <TopicChip
+              key={topic}
+              label={topic}
+              selected={selectedTopics.has(topic)}
+              onPress={() => toggleTopic(topic)}
+            />
+          ))}
+        </View>
+
+        <View style={styles.row}>
+          <TextInput
+            style={[styles.input, styles.flex]}
+            placeholder="Add custom topic"
+            value={customTopic}
+            onChangeText={setCustomTopic}
+            onSubmitEditing={addCustomTopic}
+          />
+          <Pressable style={styles.addButton} onPress={addCustomTopic}>
+            <Text style={styles.addButtonLabel}>Add</Text>
+          </Pressable>
+        </View>
+
+        <Text style={styles.sectionTitle}>Hours</Text>
+        <View style={styles.row}>
+          <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+            <View style={styles.chipContainer}>
+              {HOUR_OPTIONS.map((value) => (
+                <TopicChip
+                  key={value}
+                  label={`${value}`}
+                  selected={hours === value}
+                  onPress={() => setHours(value)}
+                />
+              ))}
+            </View>
+          </ScrollView>
+        </View>
+
+        <Text style={styles.sectionTitle}>Region</Text>
+        <TextInput
+          style={styles.input}
+          placeholder="Region code (optional)"
+          value={region}
+          onChangeText={setRegion}
+        />
+
+        <Text style={styles.sectionTitle}>Language</Text>
+        <TextInput
+          style={styles.input}
+          placeholder="Language code (optional)"
+          value={language}
+          onChangeText={setLanguage}
+        />
+
+        <Pressable style={styles.fetchButton} onPress={fetchData} disabled={loading}>
+          <Text style={styles.fetchButtonLabel}>{loading ? 'Loading…' : 'Fetch Summary'}</Text>
+        </Pressable>
+
+        {loading && <ActivityIndicator style={styles.loading} />}
+        {error && <Text style={styles.error}>{error}</Text>}
+
+        {result && !loading && (
+          <View style={styles.summaryBlock}>
+            <Text style={styles.summaryText}>{result.summary}</Text>
+            <Text style={styles.sectionTitle}>Headlines</Text>
+            {result.headlines.length === 0 ? (
+              <Text style={styles.empty}>No headlines returned.</Text>
+            ) : (
+              result.headlines.map((headline, index) => (
+                <HeadlineItem key={`${headline.url}-${index}`} headline={headline} />
+              ))
+            )}
+          </View>
+        )}
+
+        {!result && !loading && !error && (
+          <Text style={styles.empty}>Select topics and tap Fetch Summary to begin.</Text>
+        )}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f7f8fb',
+  },
+  scrollContent: {
+    padding: 16,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '600',
+    marginBottom: 12,
+  },
+  sectionTitle: {
+    marginTop: 16,
+    marginBottom: 6,
+    fontWeight: '600',
+  },
+  chipContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+  },
+  chip: {
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 16,
+    margin: 4,
+    backgroundColor: '#e0e0e0',
+  },
+  chipSelected: {
+    backgroundColor: '#4c51bf',
+  },
+  chipLabel: {
+    color: '#1a202c',
+  },
+  chipLabelSelected: {
+    color: '#ffffff',
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginVertical: 8,
+  },
+  flex: {
+    flex: 1,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#d1d5db',
+    borderRadius: 8,
+    padding: 12,
+    backgroundColor: '#ffffff',
+  },
+  addButton: {
+    marginLeft: 8,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderRadius: 8,
+    backgroundColor: '#4c51bf',
+  },
+  addButtonLabel: {
+    color: '#ffffff',
+    fontWeight: '600',
+  },
+  fetchButton: {
+    marginTop: 16,
+    paddingVertical: 14,
+    borderRadius: 10,
+    alignItems: 'center',
+    backgroundColor: '#2b6cb0',
+  },
+  fetchButtonLabel: {
+    color: '#ffffff',
+    fontWeight: '600',
+    fontSize: 16,
+  },
+  loading: {
+    marginTop: 12,
+  },
+  error: {
+    marginTop: 12,
+    color: '#c53030',
+  },
+  summaryBlock: {
+    marginTop: 24,
+    padding: 16,
+    borderRadius: 12,
+    backgroundColor: '#ffffff',
+    shadowColor: '#000',
+    shadowOpacity: 0.05,
+    shadowOffset: { width: 0, height: 2 },
+    shadowRadius: 6,
+    elevation: 2,
+  },
+  summaryText: {
+    marginBottom: 16,
+    fontSize: 16,
+    lineHeight: 22,
+  },
+  headline: {
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+    borderBottomColor: '#e5e7eb',
+  },
+  headlineTitle: {
+    fontWeight: '600',
+    marginBottom: 4,
+  },
+  headlineMeta: {
+    color: '#6b7280',
+  },
+  empty: {
+    marginTop: 16,
+    color: '#6b7280',
+  },
+});

--- a/mobile/react_native_app/README.md
+++ b/mobile/react_native_app/README.md
@@ -1,0 +1,40 @@
+# DailyNews React Native App
+
+Expo-based mobile client that consumes the DailyNews backend API.
+
+## Prerequisites
+
+- Node.js 18+
+- Expo CLI (`npm install -g expo-cli`)
+- Backend API running locally or on your network
+
+## Getting started
+
+```bash
+cp .env.example .env # optional, or export EXPO_PUBLIC_BASE_URL
+npm install
+npm run start
+```
+
+Use the Expo CLI prompts to launch on Android (`a`), iOS (`i`), or web (`w`).
+
+### Base URL tips
+
+- Android emulator: `EXPO_PUBLIC_BASE_URL=http://10.0.2.2:8000`
+- iOS simulator: `EXPO_PUBLIC_BASE_URL=http://127.0.0.1:8000`
+- Physical device: replace with your machine's LAN IP and ensure both devices are
+  on the same network.
+
+## Features
+
+- Toggleable topic chips plus custom topic entry
+- Hour presets (4/8/12/24) and optional region/language inputs
+- Loading, error, and empty states for robust UX
+- Headlines list opens URLs using the native browser
+
+## Troubleshooting
+
+- `Backend returned 404/500` – confirm the FastAPI server is running and
+  accessible from the device.
+- Expo tunnel/firewall issues – try switching to LAN mode in Expo (`s` key) and
+  ensure the port is accessible.

--- a/mobile/react_native_app/app.json
+++ b/mobile/react_native_app/app.json
@@ -1,0 +1,11 @@
+{
+  "expo": {
+    "name": "DailyNews",
+    "slug": "dailynews-rn",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "sdkVersion": "50.0.0",
+    "platforms": ["ios", "android", "web"],
+    "assetBundlePatterns": ["**/*"]
+  }
+}

--- a/mobile/react_native_app/babel.config.js
+++ b/mobile/react_native_app/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};

--- a/mobile/react_native_app/package.json
+++ b/mobile/react_native_app/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "dailynews-rn",
+  "version": "1.0.0",
+  "private": true,
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "~50.0.13",
+    "expo-status-bar": "~1.11.1",
+    "react": "18.2.0",
+    "react-native": "0.73.6"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.20.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/mobile/react_native_app/src/apiClient.ts
+++ b/mobile/react_native_app/src/apiClient.ts
@@ -1,0 +1,60 @@
+import { BASE_URL } from './config';
+
+export type Headline = {
+  title: string;
+  url: string;
+  source_domain: string;
+  seendate: string;
+};
+
+export type SummaryResponse = {
+  topics: string[];
+  hours: number;
+  region?: string | null;
+  language?: string | null;
+  fetched_count: number;
+  summary: string;
+  headlines: Headline[];
+};
+
+function buildQuery(params: Record<string, string | number | undefined | null>): string {
+  const query = Object.entries(params)
+    .filter(([, value]) => value !== undefined && value !== null && value !== '')
+    .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`)
+    .join('&');
+  return query;
+}
+
+export async function fetchSummary(options: {
+  topics: string[];
+  hours: number;
+  region?: string;
+  language?: string;
+}): Promise<SummaryResponse> {
+  const query = buildQuery({
+    topics: options.topics.join(','),
+    hours: options.hours,
+    region: options.region,
+    language: options.language,
+  });
+
+  const response = await fetch(`${BASE_URL}/summary?${query}`);
+  if (!response.ok) {
+    throw new Error(`Backend returned ${response.status}`);
+  }
+
+  const data = await response.json();
+  const topics = Array.isArray(data.topics)
+    ? data.topics.map((value: unknown) => String(value))
+    : String(data.topics ?? '').split(',').map((value) => value.trim()).filter(Boolean);
+
+  return {
+    topics,
+    hours: Number(data.hours ?? 0),
+    region: data.region ?? null,
+    language: data.language ?? null,
+    fetched_count: Number(data.fetched_count ?? 0),
+    summary: String(data.summary ?? 'No news available.'),
+    headlines: Array.isArray(data.headlines) ? data.headlines : [],
+  };
+}

--- a/mobile/react_native_app/src/config.ts
+++ b/mobile/react_native_app/src/config.ts
@@ -1,0 +1,1 @@
+export const BASE_URL = (process.env.EXPO_PUBLIC_BASE_URL ?? 'http://localhost:8000').replace(/\/$/, '');

--- a/mobile/react_native_app/tsconfig.json
+++ b/mobile/react_native_app/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": false
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dailynews"
-version = "0.1.0"
+version = "0.2.0"
 description = "Fetch, summarize, and optionally email daily news headlines."
 authors = [{name = "DailyNews Authors", email = "author@example.com"}]
 license = {text = "MIT"}
@@ -14,7 +14,12 @@ dependencies = [
     "requests>=2.31",
     "transformers>=4.40",
     "python-dotenv>=1.0",
+    "fastapi>=0.110",
+    "uvicorn[standard]>=0.23",
 ]
+
+[project.optional-dependencies]
+test = ["pytest>=7.0"]
 
 [project.scripts]
 dailynews = "dailynews.cli:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ click>=8
 requests>=2.31
 transformers>=4.40
 python-dotenv>=1.0
+fastapi>=0.110
+uvicorn[standard]>=0.23

--- a/scripts/run_server.sh
+++ b/scripts/run_server.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Helper script to start the DailyNews FastAPI server
+set -euo pipefail
+PORT="${API_PORT:-8000}"
+exec uvicorn server.main:app --reload --port "$PORT"

--- a/server/main.py
+++ b/server/main.py
@@ -1,0 +1,81 @@
+"""FastAPI application exposing DailyNews functionality."""
+from __future__ import annotations
+
+from typing import List, Optional
+
+from fastapi import FastAPI, HTTPException, Query, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from dailynews.service import summarize_run
+
+app = FastAPI(title="DailyNews API")
+
+ALLOWED_ORIGINS = [
+    "http://localhost:19006",
+    "http://localhost:3000",
+    "http://localhost:5173",
+    "http://localhost:8081",
+    "http://localhost",
+    "http://127.0.0.1",
+]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=ALLOWED_ORIGINS,
+    allow_origin_regex=r"http://127\\.0\\.0\\.1(:\\d+)?",
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+class Headline(BaseModel):
+    title: str
+    url: str
+    source_domain: str
+    seendate: str
+
+
+class SummaryResponse(BaseModel):
+    topics: List[str]
+    hours: int
+    region: Optional[str]
+    language: Optional[str]
+    fetched_count: int
+    summary: str
+    headlines: List[Headline]
+
+
+@app.exception_handler(Exception)
+async def _unhandled_exception_handler(_: Request, exc: Exception) -> JSONResponse:
+    return JSONResponse(status_code=500, content={"message": str(exc)})
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.get("/summary", response_model=SummaryResponse)
+def get_summary(
+    *,
+    topics: str = Query("finance,economy,politics", description="Comma separated topics"),
+    hours: int = Query(8, ge=1, le=72),
+    region: Optional[str] = Query(None, description="Optional region code"),
+    language: Optional[str] = Query(None, description="Optional language code"),
+    maxrecords: int = Query(75, ge=1, le=250),
+) -> SummaryResponse:
+    topic_list = [t.strip() for t in topics.split(",") if t.strip()]
+    if not topic_list:
+        raise HTTPException(status_code=400, detail={"message": "At least one topic required"})
+
+    result = summarize_run(
+        topic_list,
+        hours,
+        region=region,
+        language=language,
+        maxrecords=maxrecords,
+    )
+    return SummaryResponse(**result)

--- a/src/dailynews/__init__.py
+++ b/src/dailynews/__init__.py
@@ -1,4 +1,4 @@
 """DailyNews package."""
 
 __all__ = ["__version__"]
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/src/dailynews/cli.py
+++ b/src/dailynews/cli.py
@@ -2,12 +2,47 @@
 from __future__ import annotations
 
 import logging
+from typing import Any, Dict, List
 
 import click
+import requests
 
-from .fetcher import fetch_news
+from .config import get_settings
 from .logging_conf import configure_logging
-from .summarizer import summarize_articles
+from .service import summarize_run
+
+
+def _parse_topics(topics: str) -> List[str]:
+    parsed = [t.strip() for t in topics.split(",") if t.strip()]
+    return [topic for topic in parsed if topic]
+
+
+def _call_backend(params: Dict[str, Any]) -> Dict[str, Any]:
+    settings = get_settings()
+    base_url = settings.api_base_url.rstrip("/")
+    url = f"{base_url}/summary"
+    clean_params = {k: v for k, v in params.items() if v is not None}
+
+    try:
+        resp = requests.get(url, params=clean_params, timeout=20)
+        resp.raise_for_status()
+    except requests.RequestException as exc:
+        raise click.ClickException(f"Failed to call backend API: {exc}") from exc
+
+    try:
+        data = resp.json()
+    except ValueError as exc:  # pragma: no cover - unexpected backend response
+        raise click.ClickException("Backend API returned invalid JSON") from exc
+
+    return data
+
+
+def _extract_topics(value: Any) -> List[str]:
+    if isinstance(value, list):
+        return [str(item) for item in value]
+    if isinstance(value, str):
+        return [part.strip() for part in value.split(",") if part.strip()]
+    return []
 
 
 @click.command()
@@ -28,6 +63,11 @@ from .summarizer import summarize_articles
 )
 @click.option("--maxrecords", default=75, type=int, show_default=True)
 @click.option("--verbose", "-v", is_flag=True, help="Enable debug logging")
+@click.option(
+    "--use-api/--no-use-api",
+    default=False,
+    help="Fetch summaries from the running FastAPI backend",
+)
 def main(
     topics: str,
     hours: int,
@@ -36,41 +76,67 @@ def main(
     language: str | None,
     maxrecords: int,
     verbose: bool,
+    use_api: bool,
 ) -> None:
     """Entry point for the dailynews command."""
     configure_logging(verbose)
     logger = logging.getLogger("dailynews.cli")
 
-    topic_list = [t.strip() for t in topics.split(",") if t.strip()]
+    topic_list = _parse_topics(topics)
+    if not topic_list:
+        raise click.ClickException("Please provide at least one topic.")
+
     logger.info("Fetching news for topics: %s", ", ".join(topic_list))
 
-    articles = fetch_news(
-        topic_list,
-        hours,
-        region=region,
-        language=language,
-        maxrecords=maxrecords,
-    )
-    if not articles:
+    params = {
+        "topics": ",".join(topic_list),
+        "hours": hours,
+        "region": region,
+        "language": language,
+        "maxrecords": maxrecords,
+    }
+
+    if use_api:
+        data = _call_backend(params)
+    else:
+        data = summarize_run(
+            topic_list,
+            hours,
+            region=region,
+            language=language,
+            maxrecords=maxrecords,
+        )
+
+    topics_display = _extract_topics(data.get("topics", topic_list)) or topic_list
+    summary = str(data.get("summary") or "No news available.")
+    fetched_count = int(data.get("fetched_count", 0))
+    headlines = data.get("headlines") or []
+
+    if use_api and fetched_count == 0 and summary.lower().startswith("no news"):
+        click.echo("No articles found by backend API.")
+    elif not use_api and fetched_count == 0:
         click.echo(
             "No articles found. Check your internet connection or try different topics."
         )
         raise SystemExit(0)
 
-    summary = summarize_articles(articles)
     header = (
         "DailyNews summary for "
-        f"{', '.join(topic_list)} (last {hours}h, "
+        f"{', '.join(topics_display)} (last {hours}h, "
         f"region={region or 'All'}, lang={language or 'All'}):"
     )
     click.echo(header)
     click.echo(summary)
 
-    headlines = articles[:3]
-    if headlines:
+    top_headlines = headlines[:3]
+    if top_headlines:
         click.echo("\nTop headlines:")
-        for art in headlines:
-            domain = art.get("url", "").split("//")[-1].split("/")[0]
+        for art in top_headlines:
+            url = art.get("url", "")
+            if isinstance(url, str) and url:
+                domain = url.split("//")[-1].split("/")[0]
+            else:
+                domain = art.get("source_domain") or ""
             click.echo(f"- {art.get('title')} ({domain})")
 
     if email:

--- a/src/dailynews/config.py
+++ b/src/dailynews/config.py
@@ -1,0 +1,55 @@
+"""Configuration helpers for DailyNews."""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class Settings:
+    """Simple settings loaded from environment variables."""
+
+    hf_api_token: Optional[str]
+    hf_model: Optional[str]
+    api_port: int
+    api_base_url: str
+
+    @property
+    def has_hf_credentials(self) -> bool:
+        return bool(self.hf_api_token and self.hf_model)
+
+
+_settings_cache: Optional[Settings] = None
+
+
+def _load_settings() -> Settings:
+    token = os.getenv("HF_API_TOKEN")
+    model = os.getenv("HF_MODEL")
+    base_url = (os.getenv("DAILYNEWS_API_URL") or "http://localhost:8000").rstrip("/")
+    port_raw = os.getenv("API_PORT", "8000")
+    try:
+        port = int(port_raw)
+    except ValueError:
+        raise ValueError("API_PORT must be an integer") from None
+
+    return Settings(
+        hf_api_token=token,
+        hf_model=model,
+        api_port=port,
+        api_base_url=base_url,
+    )
+
+
+def get_settings() -> Settings:
+    """Return cached settings loaded from the environment."""
+    global _settings_cache
+    if _settings_cache is None:
+        _settings_cache = _load_settings()
+    return _settings_cache
+
+
+def reset_settings() -> None:
+    """Reset cached settings (mainly for tests)."""
+    global _settings_cache
+    _settings_cache = None

--- a/src/dailynews/service.py
+++ b/src/dailynews/service.py
@@ -1,0 +1,51 @@
+"""Shared service orchestration between CLI and API."""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from .fetcher import fetch_news
+from .summarizer import summarize_articles
+
+
+def _format_headlines(articles: List[dict], limit: int = 10) -> List[Dict[str, str]]:
+    formatted: List[Dict[str, str]] = []
+    for article in articles[:limit]:
+        formatted.append(
+            {
+                "title": str(article.get("title") or ""),
+                "url": str(article.get("url") or ""),
+                "source_domain": str(article.get("source_domain") or ""),
+                "seendate": str(article.get("seendate") or ""),
+            }
+        )
+    return formatted
+
+
+def summarize_run(
+    topics: List[str],
+    hours: int,
+    *,
+    region: Optional[str] = None,
+    language: Optional[str] = None,
+    maxrecords: int = 75,
+) -> Dict[str, Any]:
+    """Fetch articles then summarise them."""
+
+    articles = fetch_news(
+        topics,
+        hours,
+        region=region,
+        language=language,
+        maxrecords=maxrecords,
+    )
+    summary = summarize_articles(articles)
+
+    return {
+        "topics": topics,
+        "hours": hours,
+        "region": region,
+        "language": language,
+        "fetched_count": len(articles),
+        "summary": summary,
+        "headlines": _format_headlines(articles),
+    }

--- a/src/dailynews/summarizer.py
+++ b/src/dailynews/summarizer.py
@@ -3,58 +3,131 @@ from __future__ import annotations
 
 import logging
 import os
-from collections import defaultdict
-from typing import Iterable
+from typing import Callable, Iterable, List
+
+from .config import get_settings
 
 logger = logging.getLogger(__name__)
 
-_summarizer = None
+SummarizerFn = Callable[[str, str], str]
+
+_summarizer: SummarizerFn | None = None
 _MAX_CHARS = 1000
+_MAX_ARTICLES = 5
 
 
-def get_summarizer():
-    """Return a cached summarizer pipeline or a stub.
+def _build_prompt(bullet_text: str) -> str:
+    cleaned = bullet_text.strip() or "- (no headlines provided)"
+    return (
+        "Summarize the following recent news headlines into 2–4 concise sentences "
+        "for a morning briefing:\n"
+        f"{cleaned}\n"
+        "Keep it factual and brief."
+    )
 
-    When ``DAILYNEWS_SKIP_HF=1`` is set in the environment a tiny stub is
-    returned that avoids loading Hugging Face models. Otherwise the
-    ``sshleifer/distilbart-cnn-12-6`` model is loaded on first use.
-    """
+
+def get_summarizer() -> SummarizerFn:
+    """Return a cached summarizer callable."""
 
     global _summarizer
     if _summarizer is not None:
         return _summarizer
 
     if os.getenv("DAILYNEWS_SKIP_HF") == "1":
-        def _stub(text: str, **_: object) -> list[dict]:
-            return [{"summary_text": "Model disabled."}]
+        def _stub(_: str, __: str) -> str:
+            return "Summarization skipped (DAILYNEWS_SKIP_HF=1)."
 
         _summarizer = _stub
         return _summarizer
 
+    settings = get_settings()
+    if not settings.has_hf_credentials:
+        raise RuntimeError(
+            "HF_MODEL and HF_API_TOKEN must be set in the environment before "
+            "summarization can run."
+        )
+
     try:
         from transformers import pipeline  # type: ignore
 
-        _summarizer = pipeline(
-            "summarization", model="sshleifer/distilbart-cnn-12-6"
+        summarization_pipeline = pipeline(
+            "summarization",
+            model=settings.hf_model,
+            use_auth_token=settings.hf_api_token,
         )
-    except Exception as exc:  # pragma: no cover
-        logger.warning("Could not load summarization model: %s", exc)
 
-        def _fallback(text: str, **_: object) -> list[dict]:
-            return [{"summary_text": text[:200]}]
+        def _summarize(text: str, bullet_text: str) -> str:
+            normalized = (text or bullet_text).replace("\n", " ").strip()
+            result = summarization_pipeline(
+                normalized,
+                max_length=160,
+                min_length=20,
+                do_sample=False,
+            )
+            summary = result[0].get("summary_text", "") if result else ""
+            return str(summary).strip()
 
-        _summarizer = _fallback
-    return _summarizer
+        _summarizer = _summarize
+        return _summarizer
+    except Exception as exc:  # pragma: no cover - requires external model
+        logger.warning(
+            "Could not initialise summarization pipeline, falling back to text "
+            "generation: %s",
+            exc,
+        )
+        try:
+            from transformers import pipeline  # type: ignore
+
+            text_generation = pipeline(
+                "text-generation",
+                model=settings.hf_model,
+                use_auth_token=settings.hf_api_token,
+                max_new_tokens=160,
+                do_sample=False,
+                temperature=0.0,
+            )
+
+            def _generate(_: str, bullet_text: str) -> str:
+                prompt = _build_prompt(bullet_text)
+                outputs = text_generation(prompt)
+                generated = outputs[0].get("generated_text", "") if outputs else ""
+                if generated.startswith(prompt):
+                    generated = generated[len(prompt) :]
+                return generated.strip()
+
+            _summarizer = _generate
+            return _summarizer
+        except Exception as inner:  # pragma: no cover - requires external model
+            raise RuntimeError(
+                "Unable to load Hugging Face model for summarization"
+            ) from inner
 
 
-def _prepare_text(articles: Iterable[dict]) -> str:
-    parts: list[str] = []
-    for art in list(articles)[:5]:
-        title = art.get("title") or ""
-        desc = art.get("desc") or ""
-        parts.append(f"{title}. {desc}".strip())
-    combined = " ".join(p for p in parts if p)
-    return combined[:_MAX_CHARS]
+def _prepare_text(articles: Iterable[dict]) -> tuple[str, str]:
+    text_parts: List[str] = []
+    bullet_lines: List[str] = []
+    total_chars = 0
+
+    for article in list(articles)[:_MAX_ARTICLES]:
+        title = str(article.get("title") or "").strip()
+        desc = str(article.get("desc") or article.get("description") or "").strip()
+        content = " ".join(part for part in [title, desc] if part).strip()
+        if not content:
+            continue
+        content = content.replace("\n", " ")
+        remaining = _MAX_CHARS - total_chars
+        if remaining <= 0:
+            break
+        if len(content) > remaining:
+            content = content[:remaining]
+        total_chars += len(content)
+        text_parts.append(content)
+        bullet_label = title or (desc[:60] + ("..." if len(desc) > 60 else ""))
+        bullet_lines.append(f"- {bullet_label.strip()}" if bullet_label else "- (untitled)")
+
+    text = " ".join(text_parts).strip()
+    bullets = "\n".join(bullet_lines).strip()
+    return text, bullets
 
 
 def summarize_articles(articles: list[dict], per_topic: bool = False) -> str:
@@ -62,24 +135,28 @@ def summarize_articles(articles: list[dict], per_topic: bool = False) -> str:
     if not articles:
         return "No news available."
 
-    text = _prepare_text(articles)
-    if not text.strip():
+    text, bullets = _prepare_text(articles)
+    if not text and not bullets:
         return "No news available."
 
-    summ = get_summarizer()
+    summarizer = get_summarizer()
 
     try:
-        result = summ(text, max_length=100, do_sample=False)
-        summary = result[0]["summary_text"].strip()
+        summary = summarizer(text, bullets)
+    except TypeError:  # pragma: no cover - compatibility with test stubs
+        summary = summarizer(text)  # type: ignore[misc]
     except Exception as exc:  # pragma: no cover - network/other errors
         logger.warning("Summarization failed: %s", exc)
         summary = text[:200]
 
+    summary = (summary or "").strip()
     return summary or "No news available."
 
 
 def summarize_by_topic(topics: list[str], articles: list[dict]) -> dict[str, str]:
     """Group articles by topic keyword and summarize each group."""
+    from collections import defaultdict
+
     grouped: dict[str, list[dict]] = defaultdict(list)
     for art in articles:
         text = f"{art.get('title','')} {art.get('desc','')}".lower()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,20 @@
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "tests" / "stubs"))
 sys.path.insert(0, str(ROOT / "src"))
+
+from dailynews import config as config_module, summarizer
+
+
+@pytest.fixture(autouse=True)
+def _test_env(monkeypatch):
+    monkeypatch.setenv("DAILYNEWS_SKIP_HF", "1")
+    config_module.reset_settings()
+    summarizer._summarizer = None
+    yield
+    config_module.reset_settings()
+    summarizer._summarizer = None

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,52 @@
+from fastapi.testclient import TestClient
+
+from server.main import app
+
+
+def test_health_endpoint():
+    client = TestClient(app)
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_summary_endpoint(monkeypatch):
+    client = TestClient(app)
+
+    def fake_run(topics, hours, region=None, language=None, maxrecords=75):
+        assert topics == ["finance", "economy"]
+        assert hours == 8
+        assert region == "US"
+        assert language == "en"
+        return {
+            "topics": topics,
+            "hours": hours,
+            "region": region,
+            "language": language,
+            "fetched_count": 1,
+            "summary": "summary",
+            "headlines": [
+                {
+                    "title": "Title",
+                    "url": "http://example.com",
+                    "source_domain": "example.com",
+                    "seendate": "2023-01-01T00:00:00",
+                }
+            ],
+        }
+
+    monkeypatch.setattr("server.main.summarize_run", fake_run)
+
+    response = client.get(
+        "/summary",
+        params={
+            "topics": "finance,economy",
+            "hours": 8,
+            "region": "US",
+            "language": "en",
+        },
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["summary"] == "summary"
+    assert data["topics"] == ["finance", "economy"]

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,29 @@
+from dailynews import service
+
+
+def test_summarize_run(monkeypatch):
+    def fake_fetch(topics, hours, region=None, language=None, maxrecords=75):
+        assert topics == ["finance"]
+        assert hours == 8
+        assert region == "US"
+        assert language == "en"
+        return [
+            {
+                "title": "Title",
+                "url": "http://example.com",
+                "source_domain": "example.com",
+                "seendate": "2023-01-01T00:00:00",
+                "desc": "desc",
+            }
+        ]
+
+    def fake_summary(articles):
+        return "summary"
+
+    monkeypatch.setattr(service, "fetch_news", fake_fetch)
+    monkeypatch.setattr(service, "summarize_articles", fake_summary)
+
+    result = service.summarize_run(["finance"], 8, region="US", language="en")
+    assert result["fetched_count"] == 1
+    assert result["summary"] == "summary"
+    assert result["headlines"][0]["title"] == "Title"

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -6,8 +6,9 @@ def test_summarize_empty_returns_message():
 
 
 def test_summarize_basic_text_contains_keywords(monkeypatch):
-    def fake_sum(text, **kwargs):
-        return [{"summary_text": text[:50]}]
+    def fake_sum(text: str, bullet_text: str) -> str:
+        assert "Economy" in text
+        return "Summary about economy"
 
     monkeypatch.setattr(summarizer, "get_summarizer", lambda: fake_sum)
     articles = [{"title": "Economy", "desc": "The economy is booming"}]
@@ -16,13 +17,21 @@ def test_summarize_basic_text_contains_keywords(monkeypatch):
 
 
 def test_summarize_by_topic(monkeypatch):
-    def fake_sum(text, **kwargs):
-        return [{"summary_text": "summary"}]
+    def fake_sum(text: str, bullet_text: str) -> str:
+        return "summary"
 
     monkeypatch.setattr(summarizer, "get_summarizer", lambda: fake_sum)
     articles = [
-        {"title": "Economy today", "desc": "great",},
-        {"title": "Politics", "desc": "meh",},
+        {"title": "Economy today", "desc": "great"},
+        {"title": "Politics", "desc": "meh"},
     ]
     result = summarizer.summarize_by_topic(["economy", "politics"], articles)
     assert set(result) == {"economy", "politics"}
+
+
+def test_stub_used_when_skip_env(monkeypatch):
+    monkeypatch.setenv("DAILYNEWS_SKIP_HF", "1")
+    summarizer._summarizer = None
+    summary_fn = summarizer.get_summarizer()
+    result = summary_fn("text", "- bullet")
+    assert "DAILYNEWS_SKIP_HF" in result


### PR DESCRIPTION
## Summary
- add configuration helpers and shared service orchestration for fetching and summarising news
- update CLI to support --use-api mode, add FastAPI backend, and document setup plus security guidance
- scaffold Flutter and React Native clients that consume the new backend API

## Testing
- `pytest -q` *(fails: fastapi dependency unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c986ab38348322b1c0c66be51283c1