### PR TITLE
Fetch and summarize article content per headline

### DIFF
--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -16,19 +16,30 @@ def test_summarize_empty_returns_message():
 
 
 def test_summarize_basic_text_contains_keywords(monkeypatch):
+    monkeypatch.setattr(
+        summarizer,
+        "_download_article_text",
+        lambda url: "The global economy is booming thanks to innovation.",
+    )
+
     def fake_sum(text: str, bullet_text: str) -> str:
-        assert "Economy" in text
+        assert "booming" in text
+        assert bullet_text.startswith("- Economy (https://example.com/economy)")
         return "Summary about economy"
 
     monkeypatch.setattr(summarizer, "get_summarizer", lambda: fake_sum)
-    articles = [{"title": "Economy", "desc": "The economy is booming"}]
+    articles = [{"title": "Economy", "url": "https://example.com/economy"}]
     result = summarizer.summarize_articles(articles)
-    assert "economy" in result.lower()
+    assert result.startswith("- Economy (https://example.com/economy)")
+    assert "summary about economy" in result.lower()
 
 
 def test_summarize_by_topic(monkeypatch):
+    monkeypatch.setattr(summarizer, "_download_article_text", lambda _: "")
+
     def fake_sum(text: str, bullet_text: str) -> str:
-        return "summary"
+        assert bullet_text.startswith("-")
+        return f"summary for {bullet_text}"
 
     monkeypatch.setattr(summarizer, "get_summarizer", lambda: fake_sum)
     articles = [
@@ -37,6 +48,8 @@ def test_summarize_by_topic(monkeypatch):
     ]
     result = summarizer.summarize_by_topic(["economy", "politics"], articles)
     assert set(result) == {"economy", "politics"}
+    assert "summary for - Economy today" in result["economy"]
+    assert "summary for - Politics" in result["politics"]
 
 
 def test_stub_used_when_skip_env(monkeypatch):
@@ -113,3 +126,45 @@ def test_get_summarizer_auth_error_mentions_access_link(monkeypatch):
     message = str(excinfo.value)
     assert MODEL_NAME in message
     assert MODEL_URL in message
+
+
+def test_get_summarizer_prefers_token_kwarg(monkeypatch):
+    monkeypatch.delenv("DAILYNEWS_SKIP_HF", raising=False)
+    monkeypatch.setenv("HF_API_TOKEN", "secret-token")
+    monkeypatch.setenv("HF_MODEL", MODEL_NAME)
+    reset_settings()
+    summarizer._summarizer = None
+
+    fake_transformers = types.ModuleType("transformers")
+    fake_utils = types.ModuleType("transformers.utils")
+    fake_utils.is_torch_available = lambda: True
+    fake_utils.is_tf_available = lambda: False
+    fake_utils.is_flax_available = lambda: False
+
+    captured: dict[str, object] = {}
+
+    class DummyPipeline:
+        def __call__(self, *_: object, **__: object) -> list[dict[str, str]]:
+            return [{"summary_text": "ok"}]
+
+    def fake_pipeline(task: str, model: str, **kwargs: object) -> DummyPipeline:
+        captured["task"] = task
+        captured["model"] = model
+        captured["kwargs"] = kwargs
+        return DummyPipeline()
+
+    fake_transformers.utils = fake_utils  # type: ignore[attr-defined]
+    fake_transformers.pipeline = fake_pipeline  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "transformers", fake_transformers)
+    monkeypatch.setitem(sys.modules, "transformers.utils", fake_utils)
+
+    summary_fn = summarizer.get_summarizer()
+    summary_fn("text", "- bullet")
+
+    assert captured["task"] == "summarization"
+    assert captured["model"] == MODEL_NAME
+    assert captured["kwargs"].get("token") == "secret-token"
+    assert "use_auth_token" not in captured["kwargs"]
+
+    summarizer._summarizer = None


### PR DESCRIPTION
## Summary
- fetch article bodies when needed, normalise HTML content, and capture links for context
- produce per-headline summaries that include the title and link alongside the generated text
- extend summarizer tests to cover the new per-headline behaviour and remote content handling
- ensure Hugging Face pipelines use token-based authentication without leaking auth kwargs into generation calls so causal models can summarise without runtime errors

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca7c2ffa408322bf15a25ce6ced1a9